### PR TITLE
add npm deps to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,5 +19,12 @@
   "bugs": {
     "url": "https://github.com/aonghusonia/sense-hat-led/issues"
   },
-  "homepage": "https://github.com/aonghusonia/sense-hat-led#readme"
+  "homepage": "https://github.com/aonghusonia/sense-hat-led#readme",
+	"dependencies": {
+    "async": "*",
+		"glob": "7.0.3",
+		"pngjs": "2.3.1",
+		"sleep": "3.0.1",
+		"varg": "0.2.4"
+  }
 }


### PR DESCRIPTION
Added the dependencies to the package.json so when one npm installs all the needed dependencies are installed to. Tested on node 5.11.0
